### PR TITLE
fixed served directories with index.html

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -91,7 +91,7 @@ const handleFileRequest = async (req: ServerRequest) => {
 
 const handleRouteRequest = async (req: ServerRequest): Promise<void> => {
   try {
-    const file = await readFile(`${root}/${entryPoint}`)
+    const file = await readFile(`${root}${req.url}${entryPoint}`)
     const { hostname, port } = req.conn.localAddr as Deno.NetAddr
     req.respond({
       status: 200,


### PR DESCRIPTION
Hi, I have a directory with pretty urls, so requesting for urls such `/about-me/`, it should serve  the file `/about-me/index.html`. This does no work in v2.0, so made this change to fix it.