### PR TITLE
feat: windows support

### DIFF
--- a/utils/local-ip.ts
+++ b/utils/local-ip.ts
@@ -3,64 +3,56 @@
 // https://github.com/denoland/deno/issues/3802
 
 // This code is published as a module to use here: https://github.com/joakimunge/deno-local-ip/
-import { decode } from './utils.ts'
+import { decode, warn } from './utils.ts'
 
 export const getNetworkAddr = async () => {
-  let ifconfig: Deno.Process | undefined
-  const os = Deno.build.os
-  if (os === 'windows') {
-    try {
-      ifconfig = await Deno.run({
-        cmd: ['ipconfig'],
-        stdout: 'piped',
-      })
-      const { success } = await ifconfig.status()
-      if (!success) {
-        throw new Error('Subprocess ifconfig failed to run')
-      }
-      const raw = await ifconfig.output()
-      const text = decode(raw)
-      const addrs = text.match(/ipv4.+([0-9]+\.){3}[0-9]+/gi)
-      let addr = addrs ? addrs[0].match(/([0-9]+\.){3}[0-9]+/g) : undefined
-      const finaladdr = addr ? addr[0] : undefined
+  const isWin = Deno.build.os === 'windows'
+  const command = isWin ? 'ipconfig' : 'ifconfig'
+  try {
+    // initialize command
+    let ifconfig = await Deno.run({
+      cmd: [command],
+      stdout: 'piped',
+    })
+
+    // handle errors
+    const { success } = await ifconfig.status()
+    if (!success) {
+      throw new Error(`Subprocess ${command} failed to run`)
+    }
+
+    // get output
+    const raw = await ifconfig.output()
+    const text = decode(raw)
+
+    // get ip
+    if (isWin) {
+      const addrs = text.match(new RegExp('ipv4.+([0-9]+.){3}[0-9]+', 'gi'))
+      let temp = addrs
+        ? addrs[0].match(new RegExp('([0-9]+.){3}[0-9]+', 'g'))
+        : undefined
+      const addr = temp ? temp[0] : undefined
       await Deno.close(ifconfig.rid)
-      if (!addrs || !addrs.find((addr) => /([0-9]*.){3}[0-9]*$/.test(addr))) {
+      if (!addr) {
         throw new Error('Could not resolve your local adress.')
       }
-      return finaladdr
-    } catch (err) {
-      ifconfig && (await Deno.close(ifconfig.rid))
-      console.log(err.message)
-    }
-  } else {
-    try {
-      ifconfig = await Deno.run({
-        cmd: ['ifconfig'],
-        stdout: 'piped',
-      })
-      const { success } = await ifconfig.status()
-      if (!success) {
-        throw new Error('Subprocess ifconfig failed to run')
-      }
-      const raw = await ifconfig.output()
-      const text = decode(raw)
+      return addr
+    } else {
       const addrs = text.match(
         new RegExp('inet (addr:)?([0-9]*.){3}[0-9]*', 'g')
       )
+      await Deno.close(ifconfig.rid)
       if (!addrs || !addrs.some((x) => !x.startsWith('inet 127'))) {
         throw new Error('Could not resolve your local adress.')
       }
-
-      await Deno.close(ifconfig.rid)
       return (
         addrs &&
         addrs
           .find((addr: string) => !addr.startsWith('inet 127'))
           ?.split('inet ')[1]
       )
-    } catch (err) {
-      ifconfig && (await Deno.close(ifconfig.rid))
-      console.log(err.message)
     }
+  } catch (err) {
+    console.log(warn(err.message))
   }
 }

--- a/utils/local-ip.ts
+++ b/utils/local-ip.ts
@@ -3,7 +3,7 @@
 // https://github.com/denoland/deno/issues/3802
 
 // This code is published as a module to use here: https://github.com/joakimunge/deno-local-ip/
-import { decode, warn } from './utils.ts'
+import { decode, error } from './utils.ts'
 
 export const getNetworkAddr = async () => {
   const isWin = Deno.build.os === 'windows'
@@ -53,6 +53,6 @@ export const getNetworkAddr = async () => {
       )
     }
   } catch (err) {
-    console.log(warn(err.message))
+    console.log(error(err.message))
   }
 }

--- a/utils/local-ip.ts
+++ b/utils/local-ip.ts
@@ -7,32 +7,60 @@ import { decode } from './utils.ts'
 
 export const getNetworkAddr = async () => {
   let ifconfig: Deno.Process | undefined
-  try {
-    ifconfig = await Deno.run({
-      cmd: ['ifconfig'],
-      stdout: 'piped',
-    })
-    const { success } = await ifconfig.status()
-    if (!success) {
-      throw new Error('Subprocess ifconfig failed to run')
+  const os = Deno.build.os
+  if (os === 'windows') {
+    try {
+      ifconfig = await Deno.run({
+        cmd: ['ipconfig'],
+        stdout: 'piped',
+      })
+      const { success } = await ifconfig.status()
+      if (!success) {
+        throw new Error('Subprocess ifconfig failed to run')
+      }
+      const raw = await ifconfig.output()
+      const text = decode(raw)
+      const addrs = text.match(/ipv4.+([0-9]+\.){3}[0-9]+/gi)
+      let addr = addrs ? addrs[0].match(/([0-9]+\.){3}[0-9]+/g) : undefined
+      const finaladdr = addr ? addr[0] : undefined
+      await Deno.close(ifconfig.rid)
+      if (!addrs || !addrs.find((addr) => /([0-9]*.){3}[0-9]*$/.test(addr))) {
+        throw new Error('Could not resolve your local adress.')
+      }
+      return finaladdr
+    } catch (err) {
+      ifconfig && (await Deno.close(ifconfig.rid))
+      console.log(err.message)
     }
-    const raw = await ifconfig.output()
-    const text = decode(raw)
-    const addrs = text.match(new RegExp('inet (addr:)?([0-9]*.){3}[0-9]*', 'g'))
-    if (!addrs || !addrs.some((x) => !x.startsWith('inet 127'))) {
-      throw new Error('Could not resolve your local adress.')
+  } else {
+    try {
+      ifconfig = await Deno.run({
+        cmd: ['ifconfig'],
+        stdout: 'piped',
+      })
+      const { success } = await ifconfig.status()
+      if (!success) {
+        throw new Error('Subprocess ifconfig failed to run')
+      }
+      const raw = await ifconfig.output()
+      const text = decode(raw)
+      const addrs = text.match(
+        new RegExp('inet (addr:)?([0-9]*.){3}[0-9]*', 'g')
+      )
+      if (!addrs || !addrs.some((x) => !x.startsWith('inet 127'))) {
+        throw new Error('Could not resolve your local adress.')
+      }
+
+      await Deno.close(ifconfig.rid)
+      return (
+        addrs &&
+        addrs
+          .find((addr: string) => !addr.startsWith('inet 127'))
+          ?.split('inet ')[1]
+      )
+    } catch (err) {
+      ifconfig && (await Deno.close(ifconfig.rid))
+      console.log(err.message)
     }
-
-    await Deno.close(ifconfig.rid)
-
-    return (
-      addrs &&
-      addrs
-        .find((addr: string) => !addr.startsWith('inet 127'))
-        ?.split('inet ')[1]
-    )
-  } catch (err) {
-    ifconfig && (await Deno.close(ifconfig.rid))
-    console.log(err.message)
   }
 }

--- a/utils/local-ip.ts
+++ b/utils/local-ip.ts
@@ -9,23 +9,19 @@ export const getNetworkAddr = async () => {
   const isWin = Deno.build.os === 'windows'
   const command = isWin ? 'ipconfig' : 'ifconfig'
   try {
-    // initialize command
     let ifconfig = await Deno.run({
       cmd: [command],
       stdout: 'piped',
     })
 
-    // handle errors
     const { success } = await ifconfig.status()
     if (!success) {
       throw new Error(`Subprocess ${command} failed to run`)
     }
 
-    // get output
     const raw = await ifconfig.output()
     const text = decode(raw)
 
-    // get ip
     if (isWin) {
       const addrs = text.match(new RegExp('ipv4.+([0-9]+.){3}[0-9]+', 'gi'))
       let temp = addrs
@@ -53,6 +49,6 @@ export const getNetworkAddr = async () => {
       )
     }
   } catch (err) {
-    console.log(error(err.message))
+    error(err.message)
   }
 }


### PR DESCRIPTION
What i did to support windows: 
 - catch the errors that a not existing dir causes and serve the 404 site instead
 - use windows command `ipconfig` to detect the local ip.

I tested it on my windows 10 machine.
This closes #26 