### PR TITLE
Github Actions on different platforms.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        deno: ['v1.2.x', 'v1.x.x', 'nightly']
+        deno: ['v1.0.x', 'v1.x.x', 'nightly']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,19 @@
 name: ci
-
 on: [push, pull_request]
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  test:
+    strategy:
+      fail-fast: true
+      matrix:
+        deno: ['v1.2.x', 'v1.x.x', 'nightly']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@master
-      - uses: denolib/setup-deno@master
+      - uses: actions/checkout@v2.3.3
+      - uses: denolib/setup-deno@v2.2.0
         with:
-          deno-version: 1.3.0
-      - run: |
-          deno test -A
+          deno-version: ${{ matrix.deno }}
+      - run: deno --version
+        name: deno version
+      - run: deno test -A
+        name: run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.3.3
-      - uses: denolib/setup-deno@v2.2.0
+      - uses: actions/checkout@master
+      - uses: denolib/setup-deno@master
         with:
           deno-version: ${{ matrix.deno }}
       - run: deno --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        deno: ['v1.0.x', 'v1.x.x', 'nightly']
+        deno: ['v1.1.0', 'v1.x.x', 'nightly']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        deno: ['v1.1.0', 'v1.x.x', 'nightly']
+        deno: ['v1.2.x', 'v1.x.x', 'nightly']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The `deno test` task will now run on ubuntu, macOS and windows. In each platform it will try to use the following deno versions:
- The latest patch of Deno v1.2 (denoliver runs fine in Deno v1.0, but the tests don´t)
- The latest Deno v1
- Deno nightly

The task also will run `deno --version` to ensure Deno is set up correctly and to provide the ability to quickly get the exact version.

Currently there is a deprecation warning, because [denolib/setup-deno](https://github.com/denolib/setup-deno) uses the deprecated `add-path` command. [read more](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

Please merge this after #26 because all tests in a windows container are still failing here.