### PR TITLE
feat: test on different platforms and deno versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,17 @@
 name: ci
-
 on: [push, pull_request]
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  test:
+    strategy:
+      fail-fast: true
+      matrix:
+        deno: ['v1.0.x', 'v1.x.x', 'nightly']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
       - uses: denolib/setup-deno@master
         with:
-          deno-version: 1.3.0
-      - run: |
-          deno test -A
+          deno-version: ${{ matrix.deno }}
+      - run: deno --version
+      - run: deno test -A

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        deno: ['v1.0.x', 'v1.x.x', 'nightly']
+        deno: ['v1.2.x', 'v1.x.x', 'nightly']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The deno test task will now run on ubuntu, macOS and windows. In each platform it will try to use the following deno versions:

-  The latest patch of deno v1.2 (denoliver runs fine on deno v1.0, but the tests don't)
-  The latest deno with major version 1
-  deno nightly

This closes #29 an depends on #35.